### PR TITLE
add baconjs as peer and dev dependency instead of dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -755,7 +755,8 @@
     "baconjs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/baconjs/-/baconjs-1.0.0.tgz",
-      "integrity": "sha512-xtPIez7j0xW6Z8qbNcXo5Q/rVNmmdlUhS5GkNj3DlZsutKsdQL4d0L9mqoy34pWMLKXQKEihQfhEDx6bdieiCA=="
+      "integrity": "sha512-xtPIez7j0xW6Z8qbNcXo5Q/rVNmmdlUhS5GkNj3DlZsutKsdQL4d0L9mqoy34pWMLKXQKEihQfhEDx6bdieiCA==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "homepage": "https://github.com/calmm-js/bacon.atom#readme",
   "dependencies": {
-    "baconjs": ">0.7 <2.0",
     "infestines": ">=0.2.0 <0.5.0",
     "partial.lenses": ">=2.2.0"
   },
@@ -40,6 +39,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
+    "baconjs": ">0.7 <2.0",
     "codecov": "^2.3.0",
     "eslint": "^4.6.1",
     "mocha": "^3.5.0",
@@ -50,5 +50,8 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify": "^2.0.1"
+  },
+  "peerDependencies": {
+    "baconjs": ">0.7 <2.0"
   }
 }


### PR DESCRIPTION
This is the same issue as with baret@1.0.6, explained in detail here: https://github.com/calmm-js/baret/pull/2